### PR TITLE
Reaction api post and delete

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -2,11 +2,9 @@
 
 module DiscourseReactions
   class CustomReactionsController < DiscourseReactionsController
+    before_action :fetch_post_from_params
+
     def index
-      post = Post.find(params[:post_id])
-
-      guardian.ensure_can_see!(post)
-
       user = User.last
 
       reactions = [
@@ -30,6 +28,41 @@ module DiscourseReactions
       ]
 
       render json: reactions
+    end
+
+    def create
+      return render_json_error(@post) unless DiscourseReactions::Reaction.valid_reactions.include?(params[:reaction])
+      reaction_scope.first_or_create!
+      add_or_remove_shadow_like
+      render_json_dump(post_serializer.as_json)
+    end
+
+    def destroy
+      reaction_scope.delete_all
+      render_json_dump(post_serializer.as_json)
+    end
+
+    private 
+
+    def add_or_remove_shadow_like
+      # TODO add like when positive emoji exists and like was not already given
+      # TODO remove like when all positive emojis are removed for specific user and post
+    end
+
+    def reaction_scope
+      DiscourseReactions::Reaction.where(post_id: @post.id,
+                                         user_id: current_user.id,
+                                         reaction_value: params[:reaction],
+                                         reaction_type:  DiscourseReactions::Reaction.reaction_types['emoji'])
+    end
+
+    def post_serializer
+      PostSerializer.new(@post, scope: guardian, root: false)
+    end
+
+    def fetch_post_from_params
+      @post = Post.find(params[:post_id])
+      guardian.ensure_can_see!(@post)
     end
   end
 end

--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -12,5 +12,15 @@ module DiscourseReactions
     def self.valid_reactions
       SiteSetting.discourse_reactions_enabled_reactions.split(/\|-?/)
     end
+
+    def self.positive_reactions
+      valid_reactions - negative_or_neutral_reactions
+    end
+
+    def self.negative_or_neutral_reactions
+      SiteSetting.discourse_reactions_enabled_reactions.split('|').map do |reaction|
+        reaction =~ /^\-/ ? reaction.delete_prefix("-") : nil
+      end.compact
+    end
   end
 end

--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -8,5 +8,9 @@ module DiscourseReactions
 
     belongs_to :user
     belongs_to :post
+
+    def self.valid_reactions
+      SiteSetting.discourse_reactions_enabled_reactions.split(/\|-?/)
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -44,6 +44,8 @@ after_initialize do
 
   DiscourseReactions::Engine.routes.draw do
     get '/discourse-reactions/custom-reactions' => 'custom_reactions#index', constraints: { format: :json }
+    post '/discourse-reactions/custom_reactions' => 'custom_reactions#create', constraints: { format: :json }
+    delete '/discourse-reactions/custom_reactions' => 'custom_reactions#destroy', constraints: { format: :json }
   end
 
   add_to_serializer(:post, :reactions) do

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe DiscourseReactions::Reaction do
+  it 'knows which reactions are positive and which are negative' do
+    SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|-open_mouth|-cry|-angry|thumbsup|-thumbsdown"
+    expect(described_class.valid_reactions).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown))
+    expect(described_class.positive_reactions).to eq(%w(laughing heart thumbsup))
+    expect(described_class.negative_or_neutral_reactions).to eq(%w(open_mouth cry angry thumbsdown))
+  end
+end

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+require_relative '../fabricators/reaction_fabricator.rb'
+
+describe DiscourseReactions::CustomReactionsController do
+  fab!(:post_1) { Fabricate(:post) }
+  fab!(:user_1) { Fabricate(:user) }
+
+  before do
+    sign_in(user_1)
+  end
+
+  context 'POST' do
+    it 'creates reaction if does not exists' do
+      expected_reactions_payload = [
+        {
+          'id' => 'thumbsup',
+          'type' => 'emoji',
+          'users' => [
+            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template }
+          ],
+          'count' => 1
+        }
+      ]
+      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: "thumbsup" }
+      expect(DiscourseReactions::Reaction.count).to eq(1)
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['reactions']).to eq(expected_reactions_payload)
+
+      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: "thumbsup" }
+      expect(DiscourseReactions::Reaction.count).to eq(1)
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['reactions']).to eq(expected_reactions_payload)
+    end
+
+    it 'errors when emoji is invalid' do
+      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: "invalid_emoji" }
+      expect(DiscourseReactions::Reaction.count).to eq(0)
+      expect(response.status).to eq(422)
+    end
+  end
+
+  context 'DELETE' do
+    it 'deletes reaction if exists' do
+      reaction = Fabricate(:reaction, user: user_1, post: post_1)
+      delete '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: "otter" }
+      expect(response.status).to eq(200)
+      expect { reaction.reload }.to raise_error ActiveRecord::RecordNotFound
+    end
+  end
+end


### PR DESCRIPTION
API to post/delete reaction

One step left here which is creating/deleting shadow likes. We need to decide if we want to use `discourse_reactions_like_icon` setting or simply create shadow like for any "positive" reaction. 

@jjaffeux could you take a look on that PR? I fixed your comments from previous one + I solved N+1 problem so I merged one about serializer