### PR TITLE
FIX: refactor data model for reactions

### DIFF
--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -6,7 +6,8 @@ module DiscourseReactions
 
     enum reaction_type: { emoji: 0 }
 
-    belongs_to :user
+    has_many :reaction_users, class_name: 'DiscourseReactions::ReactionUser'
+    has_many :users, through: :reaction_users
     belongs_to :post
 
     def self.valid_reactions

--- a/app/models/discourse_reactions/reaction_user.rb
+++ b/app/models/discourse_reactions/reaction_user.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module DiscourseReactions
+  class ReactionUser < ActiveRecord::Base
+    self.table_name = 'discourse_reactions_reaction_users'
+
+    belongs_to :reaction, class_name: 'DiscourseReactions::Reaction'
+    belongs_to :user
+
+    delegate :username, to: :user
+    delegate :avatar_template, to: :user
+  end
+end

--- a/app/models/discourse_reactions/reaction_user.rb
+++ b/app/models/discourse_reactions/reaction_user.rb
@@ -4,7 +4,7 @@ module DiscourseReactions
   class ReactionUser < ActiveRecord::Base
     self.table_name = 'discourse_reactions_reaction_users'
 
-    belongs_to :reaction, class_name: 'DiscourseReactions::Reaction'
+    belongs_to :reaction, class_name: 'DiscourseReactions::Reaction', counter_cache: true
     belongs_to :user
 
     delegate :username, to: :user

--- a/db/migrate/20200610225109_create_discourse_reactions_reactions_table.rb
+++ b/db/migrate/20200610225109_create_discourse_reactions_reactions_table.rb
@@ -4,11 +4,12 @@ class CreateDiscourseReactionsReactionsTable < ActiveRecord::Migration[6.0]
   def change
     create_table :discourse_reactions_reactions do |t|
       t.integer :post_id
-      t.integer :user_id
       t.integer :reaction_type
       t.string :reaction_value
+      t.integer :count_cache, default: 0
+      t.timestamps
     end
     add_index :discourse_reactions_reactions, :post_id
-    add_index :discourse_reactions_reactions, :user_id
+    add_index :discourse_reactions_reactions, [:post_id, :reaction_type, :reaction_value], unique: true, name: 'reaction_type_reaction_value'
   end
 end

--- a/db/migrate/20200610225109_create_discourse_reactions_reactions_table.rb
+++ b/db/migrate/20200610225109_create_discourse_reactions_reactions_table.rb
@@ -6,7 +6,7 @@ class CreateDiscourseReactionsReactionsTable < ActiveRecord::Migration[6.0]
       t.integer :post_id
       t.integer :reaction_type
       t.string :reaction_value
-      t.integer :count_cache, default: 0
+      t.integer :reaction_users_count
       t.timestamps
     end
     add_index :discourse_reactions_reactions, :post_id

--- a/db/migrate/20200614225514_create_discourse_reactions_reaction_users_table.rb
+++ b/db/migrate/20200614225514_create_discourse_reactions_reaction_users_table.rb
@@ -1,0 +1,11 @@
+class CreateDiscourseReactionsReactionUsersTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :discourse_reactions_reaction_users do |t|
+      t.integer :reaction_id
+      t.integer :user_id
+      t.timestamps
+    end
+    add_index :discourse_reactions_reaction_users, :reaction_id
+    add_index :discourse_reactions_reaction_users, [:reaction_id, :user_id], unique: true, name: 'reaction_id_user_id'
+  end
+end

--- a/lib/discourse_reactions/topic_view_extension.rb
+++ b/lib/discourse_reactions/topic_view_extension.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module DiscourseReactions::TopicViewExtension
-  def filter_posts_by_ids(post_ids)
-    return super(post_ids) unless SiteSetting.discourse_reactions_enabled
-    super(post_ids).includes(reactions: [:user])
+  def filter_post_types(posts)
+    return super(posts) unless SiteSetting.discourse_reactions_enabled
+    super(posts).includes(reactions: { reaction_users: :user })
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -29,6 +29,7 @@ after_initialize do
     "../app/controllers/discourse_reactions_controller.rb",
     "../app/controllers/discourse_reactions/custom_reactions_controller.rb",
     "../app/models/discourse_reactions/reaction.rb",
+    "../app/models/discourse_reactions/reaction_user.rb",
     "../lib/discourse_reactions/post_extension.rb",
     "../lib/discourse_reactions/topic_view_extension.rb"
   ].each { |path| load File.expand_path(path, __FILE__) }
@@ -49,14 +50,13 @@ after_initialize do
   end
 
   add_to_serializer(:post, :reactions) do
-    object.reactions.each_with_object({}) do |reaction, result|
-      key = reaction.reaction_value
-      result[key] = {
-        id: key,
+    object.reactions.map do |reaction|
+      {
+        id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
-        users: (result.dig(key, :users) || []) << { username: reaction.user.username, avatar_template: reaction.user.avatar_template },
-        count: result.dig(key, :count).to_i + 1
+        users: reaction.reaction_users.map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template } },
+        count: reaction.count_cache
       }
-    end.values
+    end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -45,8 +45,7 @@ after_initialize do
 
   DiscourseReactions::Engine.routes.draw do
     get '/discourse-reactions/custom-reactions' => 'custom_reactions#index', constraints: { format: :json }
-    post '/discourse-reactions/custom_reactions' => 'custom_reactions#create', constraints: { format: :json }
-    delete '/discourse-reactions/custom_reactions' => 'custom_reactions#destroy', constraints: { format: :json }
+    put '/discourse-reactions/posts/:post_id/custom_reactions/:reaction/toggle' => 'custom_reactions#toggle', constraints: { format: :json }
   end
 
   add_to_serializer(:post, :reactions) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -55,7 +55,7 @@ after_initialize do
         id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
         users: reaction.reaction_users.map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template } },
-        count: reaction.count_cache
+        count: reaction.reaction_users_count
       }
     end
   end

--- a/spec/fabricators/reaction_fabricator.rb
+++ b/spec/fabricators/reaction_fabricator.rb
@@ -4,5 +4,4 @@ Fabricator(:reaction, class_name: 'DiscourseReactions::Reaction') do
   post { |attrs| attrs[:post] }
   reaction_type 0
   reaction_value 'otter'
-  count_cache 1
 end

--- a/spec/fabricators/reaction_fabricator.rb
+++ b/spec/fabricators/reaction_fabricator.rb
@@ -2,7 +2,7 @@
 
 Fabricator(:reaction, class_name: 'DiscourseReactions::Reaction') do
   post { |attrs| attrs[:post] }
-  user { |attrs| attrs[:user] }
   reaction_type 0
   reaction_value 'otter'
+  count_cache 1
 end

--- a/spec/fabricators/reaction_user_fabricator.rb
+++ b/spec/fabricators/reaction_user_fabricator.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+Fabricator(:reaction_user, class_name: 'DiscourseReactions::ReactionUser') do
+  reaction { |attrs| attrs[:reaction] }
+  user { |attrs| attrs[:user] }
+end

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -36,13 +36,13 @@ describe DiscourseReactions::CustomReactionsController do
 
       reaction = DiscourseReactions::Reaction.last
       expect(reaction.reaction_value). to eq('thumbsup')
-      expect(reaction.count_cache). to eq(1)
+      expect(reaction.reaction_users_count). to eq(1)
 
       sign_in(user_2)
       post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'thumbsup' }
       reaction = DiscourseReactions::Reaction.last
       expect(reaction.reaction_value). to eq('thumbsup')
-      expect(reaction.count_cache). to eq(2)
+      expect(reaction.reaction_users_count). to eq(2)
     end
 
     it 'errors when emoji is invalid' do
@@ -55,13 +55,13 @@ describe DiscourseReactions::CustomReactionsController do
   context 'DELETE' do
     it 'deletes reaction if exists' do
       sign_in(user_1)
-      reaction = Fabricate(:reaction, post: post_1, count_cache: 2)
+      reaction = Fabricate(:reaction, post: post_1)
       Fabricate(:reaction_user, reaction: reaction, user: user_1)
       Fabricate(:reaction_user, reaction: reaction, user: user_2)
 
       delete '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'otter' }
       expect(response.status).to eq(200)
-      expect(reaction.reload.count_cache).to eq(1)
+      expect(reaction.reload.reaction_users_count).to eq(1)
 
       sign_in(user_2)
       delete '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'otter' }

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -9,10 +9,9 @@ describe DiscourseReactions::CustomReactionsController do
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
 
-  context 'POST' do
-    it 'creates reaction record if does not exists and cache count' do
-      sign_in(user_1)
-      expected_reactions_payload = [
+  context '#toggle' do
+    let(:payload_with_user) {
+      [
         {
           'id' => 'thumbsup',
           'type' => 'emoji',
@@ -22,50 +21,60 @@ describe DiscourseReactions::CustomReactionsController do
           'count' => 1
         }
       ]
-      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'thumbsup' }
-      expect(DiscourseReactions::Reaction.count).to eq(1)
-      expect(DiscourseReactions::ReactionUser.count).to eq(1)
-      expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)['reactions']).to eq(expected_reactions_payload)
+    }
 
-      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'thumbsup' }
+    it 'toggles reaction' do
+      sign_in(user_1)
+      expected_payload = [
+        {
+          'id' => 'thumbsup',
+          'type' => 'emoji',
+          'users' => [
+            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template }
+          ],
+          'count' => 1
+        }
+      ]
+      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(1)
       expect(DiscourseReactions::ReactionUser.count).to eq(1)
       expect(response.status).to eq(200)
-      expect(JSON.parse(response.body)['reactions']).to eq(expected_reactions_payload)
+      expect(JSON.parse(response.body)['reactions']).to eq(expected_payload)
 
       reaction = DiscourseReactions::Reaction.last
       expect(reaction.reaction_value). to eq('thumbsup')
       expect(reaction.reaction_users_count). to eq(1)
 
       sign_in(user_2)
-      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'thumbsup' }
+      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
       reaction = DiscourseReactions::Reaction.last
       expect(reaction.reaction_value). to eq('thumbsup')
-      expect(reaction.reaction_users_count). to eq(2)
+      expect(reaction.reaction_users_count).to eq(2)
+      expect(JSON.parse(response.body)['reactions'][0]['users']).to eq([
+        { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template },
+        { 'username' => user_2.username, 'avatar_template' => user_2.avatar_template }
+      ])
+
+      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      expect(DiscourseReactions::Reaction.count).to eq(1)
+      expect(DiscourseReactions::ReactionUser.count).to eq(1)
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['reactions']).to eq(expected_payload)
+
+      sign_in(user_1)
+      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      expect(DiscourseReactions::Reaction.count).to eq(0)
+      expect(DiscourseReactions::ReactionUser.count).to eq(0)
+      expect(response.status).to eq(200)
+      expect(JSON.parse(response.body)['reactions']).to eq([])
+
     end
 
-    it 'errors when emoji is invalid' do
-      post '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'invalid_emoji' }
+    it 'errors when reaction is invalid' do
+      sign_in(user_1)
+      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/invalid-reaction/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(0)
       expect(response.status).to eq(422)
-    end
-  end
-
-  context 'DELETE' do
-    it 'deletes reaction if exists' do
-      sign_in(user_1)
-      reaction = Fabricate(:reaction, post: post_1)
-      Fabricate(:reaction_user, reaction: reaction, user: user_1)
-      Fabricate(:reaction_user, reaction: reaction, user: user_2)
-
-      delete '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'otter' }
-      expect(response.status).to eq(200)
-      expect(reaction.reload.reaction_users_count).to eq(1)
-
-      sign_in(user_2)
-      delete '/discourse-reactions/custom_reactions.json', params: { post_id: post_1.id, reaction: 'otter' }
-      expect { reaction.reload }.to raise_error ActiveRecord::RecordNotFound
     end
   end
 end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -2,15 +2,18 @@
 
 require 'rails_helper'
 require_relative '../fabricators/reaction_fabricator.rb'
+require_relative '../fabricators/reaction_user_fabricator.rb'
 
 
 describe PostSerializer do
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:post_1) { Fabricate(:post, user: user_1) }
-  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, user: user_1) }
-  fab!(:reaction_2) { Fabricate(:reaction, post: post_1, user: user_2) }
-  fab!(:reaction_3) { Fabricate(:reaction, reaction_value: "thumbs-up", post: post_1, user: user_2) }
+  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, count_cache: 2) }
+  fab!(:reaction_user_1) { Fabricate(:reaction_user, reaction: reaction_1, user: user_1) }
+  fab!(:reaction_user_2) { Fabricate(:reaction_user, reaction: reaction_1, user: user_2) }
+  fab!(:reaction_2) { Fabricate(:reaction, reaction_value: "thumbs-up", post: post_1) }
+  fab!(:reaction_user_3) { Fabricate(:reaction_user, reaction: reaction_2, user: user_2) }
 
   it 'renders custom reactions' do
     json = PostSerializer.new(post_1, scope: Guardian.new(user_1), root: false).as_json

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -9,7 +9,7 @@ describe PostSerializer do
   fab!(:user_1) { Fabricate(:user) }
   fab!(:user_2) { Fabricate(:user) }
   fab!(:post_1) { Fabricate(:post, user: user_1) }
-  fab!(:reaction_1) { Fabricate(:reaction, post: post_1, count_cache: 2) }
+  fab!(:reaction_1) { Fabricate(:reaction, post: post_1) }
   fab!(:reaction_user_1) { Fabricate(:reaction_user, reaction: reaction_1, user: user_1) }
   fab!(:reaction_user_2) { Fabricate(:reaction_user, reaction: reaction_1, user: user_2) }
   fab!(:reaction_2) { Fabricate(:reaction, reaction_value: "thumbs-up", post: post_1) }


### PR DESCRIPTION
This was inspired by Sam during our Friday call. He said that because that plugin may become popular we need to be sure it is performant. He suggested that we should cache count, something similar to `likes_count` column on posts. I was thinking over the weekend and that gave me the idea that we should restructure it a little bit.

I think we should have two tables in the database.

One is `reactions` which would contain information about reactions and count:
```
      t.integer :post_id
      t.integer :reaction_type
      t.string :reaction_value
      t.integer :count_cache, default: 0
      t.timestamps
```
and `reaction_users` which would give us information who reacted:
```
      t.integer :reaction_id
      t.integer :user_id
      t.timestamps
```

That simplified logic around serializer which I was worried about. In theory, it was a simple ruby calculation of how many reactions we have but for a very popular topic with many reactions, it might be a bottleneck.
https://github.com/discourse/discourse-reactions/blob/master/plugin.rb#L52

@jjaffeux I am very curious about what do you think.

I know that editing migration is not a good idea, but because it is just you, me and `dev` I can sort it out. Once you say that its new structure is fine, I will drop reactions tables in `dev` and remove numbers from `schema_migrations` by hand.