### PR TITLE
FIX: Allow to remove reaction in limited time

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -11,6 +11,10 @@ module DiscourseReactions
         reaction_user = reaction_user_scope(reaction)&.first_or_initialize
 
         if reaction_user.persisted?
+          unless guardian.can_delete_reaction_user?(reaction_user)
+            return render json: failed_json.merge(errors: I18n.t("invalid_access")), status: 400
+          end
+
           reaction_user.destroy
           remove_shadow_like(reaction) if reaction.positive?
           remove_reaction_notification(reaction) if reaction.negative?

--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -22,13 +22,21 @@ module DiscourseReactions
     end
 
     def self.positive_reactions
-      valid_reactions - negative_or_neutral_reactions
+      (valid_reactions - negative_or_neutral_reactions).to_set
     end
 
     def self.negative_or_neutral_reactions
       SiteSetting.discourse_reactions_enabled_reactions.split('|').map do |reaction|
         reaction =~ /^\-/ ? reaction.delete_prefix("-") : nil
-      end.compact
+      end.compact.to_set
+    end
+
+    def positive?
+      self.class.positive_reactions.include?(reaction_value)
+    end
+
+    def negative?
+      self.class.negative_or_neutral_reactions.include?(reaction_value)
     end
 
     private
@@ -44,14 +52,6 @@ module DiscourseReactions
       else
         'heart'
       end
-    end
-
-    def positive?
-      self.class.positive_reactions.include?(reaction_value)
-    end
-
-    def negative?
-      self.class.negative_or_neutral_reactions.include?(reaction_value)
     end
   end
 end

--- a/app/models/discourse_reactions/reaction_user.rb
+++ b/app/models/discourse_reactions/reaction_user.rb
@@ -9,5 +9,9 @@ module DiscourseReactions
 
     delegate :username, to: :user
     delegate :avatar_template, to: :user
+
+    def can_undo?
+      self.created_at > SiteSetting.post_undo_action_window_mins.minutes.ago
+    end
   end
 end

--- a/lib/discourse_reactions/guardian_extension.rb
+++ b/lib/discourse_reactions/guardian_extension.rb
@@ -2,6 +2,6 @@
 
 module DiscourseReactions::GuardianExtension
   def can_delete_reaction_user?(reaction_user)
-    reaction_user.created_at > SiteSetting.post_undo_action_window_mins.minutes.ago
+    reaction_user.can_undo?
   end
 end

--- a/lib/discourse_reactions/guardian_extension.rb
+++ b/lib/discourse_reactions/guardian_extension.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module DiscourseReactions::GuardianExtension
+  def can_delete_reaction_user?(reaction_user)
+    reaction_user.created_at > SiteSetting.post_undo_action_window_mins.minutes.ago
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -34,13 +34,15 @@ after_initialize do
     "../lib/discourse_reactions/post_extension.rb",
     "../lib/discourse_reactions/topic_view_extension.rb",
     "../lib/discourse_reactions/notification_extension.rb",
-    "../lib/discourse_reactions/post_alerter_extension.rb"
+    "../lib/discourse_reactions/post_alerter_extension.rb",
+    "../lib/discourse_reactions/guardian_extension.rb"
   ].each { |path| load File.expand_path(path, __FILE__) }
 
   reloadable_patch do |plugin|
     Post.class_eval { prepend DiscourseReactions::PostExtension }
     TopicView.class_eval { prepend DiscourseReactions::TopicViewExtension }
     PostAlerter.class_eval { prepend DiscourseReactions::PostAlerterExtension }
+    Guardian.class_eval { prepend DiscourseReactions::GuardianExtension }
     Notification.singleton_class.class_eval { prepend DiscourseReactions::NotificationExtension }
   end
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -60,7 +60,7 @@ after_initialize do
       {
         id: reaction.reaction_value,
         type: reaction.reaction_type.to_sym,
-        users: reaction.reaction_users.map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template } },
+        users: reaction.reaction_users.map { |reaction_user| { username: reaction_user.username, avatar_template: reaction_user.avatar_template, can_undo: reaction_user.can_undo? } },
         count: reaction.reaction_users_count
       }
     end

--- a/spec/models/reaction_spec.rb
+++ b/spec/models/reaction_spec.rb
@@ -1,13 +1,14 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require_relative '../fabricators/reaction_fabricator.rb'
 
 describe DiscourseReactions::Reaction do
   it 'knows which reactions are positive and which are negative' do
     SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|-open_mouth|-cry|-angry|thumbsup|-thumbsdown"
-    expect(described_class.valid_reactions).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown))
-    expect(described_class.positive_reactions).to eq(%w(laughing heart thumbsup))
-    expect(described_class.negative_or_neutral_reactions).to eq(%w(open_mouth cry angry thumbsdown))
+    expect(described_class.valid_reactions).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown).to_set)
+    expect(described_class.positive_reactions).to eq(%w(laughing heart thumbsup).to_set)
+    expect(described_class.negative_or_neutral_reactions).to eq(%w(open_mouth cry angry thumbsdown).to_set)
   end
 
   it 'positive and negative scopes' do

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -16,7 +16,7 @@ describe DiscourseReactions::CustomReactionsController do
           'id' => 'thumbsup',
           'type' => 'emoji',
           'users' => [
-            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template }
+            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template, 'can_undo' => true }
           ],
           'count' => 1
         }
@@ -30,7 +30,7 @@ describe DiscourseReactions::CustomReactionsController do
           'id' => 'thumbsup',
           'type' => 'emoji',
           'users' => [
-            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template }
+            { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template, 'can_undo' => true }
           ],
           'count' => 1
         }
@@ -51,8 +51,8 @@ describe DiscourseReactions::CustomReactionsController do
       expect(reaction.reaction_value). to eq('thumbsup')
       expect(reaction.reaction_users_count).to eq(2)
       expect(JSON.parse(response.body)['reactions'][0]['users']).to eq([
-        { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template },
-        { 'username' => user_2.username, 'avatar_template' => user_2.avatar_template }
+        { 'username' => user_1.username, 'avatar_template' => user_1.avatar_template, 'can_undo' => true },
+        { 'username' => user_2.username, 'avatar_template' => user_2.avatar_template, 'can_undo' => true }
       ])
 
       put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"

--- a/spec/requests/custom_reactions_controller_spec.rb
+++ b/spec/requests/custom_reactions_controller_spec.rb
@@ -35,7 +35,7 @@ describe DiscourseReactions::CustomReactionsController do
           'count' => 1
         }
       ]
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(1)
       expect(DiscourseReactions::ReactionUser.count).to eq(1)
       expect(response.status).to eq(200)
@@ -46,7 +46,7 @@ describe DiscourseReactions::CustomReactionsController do
       expect(reaction.reaction_users_count). to eq(1)
 
       sign_in(user_2)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       reaction = DiscourseReactions::Reaction.last
       expect(reaction.reaction_value). to eq('thumbsup')
       expect(reaction.reaction_users_count).to eq(2)
@@ -55,14 +55,14 @@ describe DiscourseReactions::CustomReactionsController do
         { 'username' => user_2.username, 'avatar_template' => user_2.avatar_template }
       ])
 
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(1)
       expect(DiscourseReactions::ReactionUser.count).to eq(1)
       expect(response.status).to eq(200)
       expect(JSON.parse(response.body)['reactions']).to eq(expected_payload)
 
       sign_in(user_1)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(0)
       expect(DiscourseReactions::ReactionUser.count).to eq(0)
       expect(response.status).to eq(200)
@@ -72,7 +72,7 @@ describe DiscourseReactions::CustomReactionsController do
 
     it 'errors when reaction is invalid' do
       sign_in(user_1)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/invalid-reaction/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/invalid-reaction/toggle.json"
       expect(DiscourseReactions::Reaction.count).to eq(0)
       expect(response.status).to eq(422)
     end
@@ -85,30 +85,30 @@ describe DiscourseReactions::CustomReactionsController do
 
     it 'creates notification when first positive like' do
       sign_in(user_1)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(Notification.count).to eq(1)
       expect(PostAction.count).to eq(1)
       expect(PostAction.last.post_action_type_id).to eq(PostActionType.types[:like])
 
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/laughing/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/laughing/toggle.json"
       expect(Notification.count).to eq(1)
       expect(PostAction.count).to eq(1)
 
       sign_in(user_2)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(Notification.count).to eq(1)
       expect(PostAction.count).to eq(2)
 
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(Notification.count).to eq(1)
       expect(PostAction.count).to eq(1)
 
       sign_in(user_1)
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsup/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
       expect(Notification.count).to eq(1)
       expect(PostAction.count).to eq(1)
 
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/laughing/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/laughing/toggle.json"
       expect(Notification.count).to eq(0)
       expect(PostAction.count).to eq(0)
     end
@@ -119,8 +119,27 @@ describe DiscourseReactions::CustomReactionsController do
       sign_in(user_1)
       DiscourseReactions::ReactionNotification.any_instance.expects(:create).once
       DiscourseReactions::ReactionNotification.any_instance.expects(:delete).once
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsdown/toggle.json"
-      put "/discourse-reactions/posts/#{post_1.id}/custom_reactions/thumbsdown/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsdown/toggle.json"
+      put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsdown/toggle.json"
     end
+  end
+
+  it 'allows to delete reaction only in undo action window frame' do
+    SiteSetting.post_undo_action_window_mins = 10
+    sign_in(user_1)
+    put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
+    expect(DiscourseReactions::Reaction.count).to eq(1)
+    expect(DiscourseReactions::ReactionUser.count).to eq(1)
+    put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
+    expect(DiscourseReactions::Reaction.count).to eq(0)
+    expect(DiscourseReactions::ReactionUser.count).to eq(0)
+    put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
+    expect(DiscourseReactions::Reaction.count).to eq(1)
+    expect(DiscourseReactions::ReactionUser.count).to eq(1)
+    freeze_time(Time.zone.now + 11.minutes)
+    put "/discourse-reactions/posts/#{post_1.id}/custom-reactions/thumbsup/toggle.json"
+    expect(DiscourseReactions::Reaction.count).to eq(1)
+    expect(DiscourseReactions::ReactionUser.count).to eq(1)
+    expect(response.status).to eq(400)
   end
 end

--- a/spec/serializers/post_serializer_spec.rb
+++ b/spec/serializers/post_serializer_spec.rb
@@ -13,17 +13,18 @@ describe PostSerializer do
   fab!(:reaction_user_1) { Fabricate(:reaction_user, reaction: reaction_1, user: user_1) }
   fab!(:reaction_user_2) { Fabricate(:reaction_user, reaction: reaction_1, user: user_2) }
   fab!(:reaction_2) { Fabricate(:reaction, reaction_value: "thumbs-up", post: post_1) }
-  fab!(:reaction_user_3) { Fabricate(:reaction_user, reaction: reaction_2, user: user_2) }
+  fab!(:reaction_user_3) { Fabricate(:reaction_user, reaction: reaction_2, user: user_2, created_at: 20.minutes.ago) }
 
   it 'renders custom reactions' do
+    SiteSetting.post_undo_action_window_mins = 10
     json = PostSerializer.new(post_1, scope: Guardian.new(user_1), root: false).as_json
     expect(json[:reactions]).to eq([
       {
         id: 'otter',
         type: :emoji,
         users: [
-          { username: user_1.username, avatar_template: user_1.avatar_template },
-          { username: user_2.username, avatar_template: user_2.avatar_template }
+          { username: user_1.username, avatar_template: user_1.avatar_template, can_undo: true },
+          { username: user_2.username, avatar_template: user_2.avatar_template, can_undo: true }
         ],
         count: 2
       },
@@ -31,7 +32,7 @@ describe PostSerializer do
         id: 'thumbs-up',
         type: :emoji,
         users: [
-          { username: user_2.username, avatar_template: user_2.avatar_template }
+          { username: user_2.username, avatar_template: user_2.avatar_template, can_undo: false }
         ],
         count: 1
       }

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -11,6 +11,6 @@ describe TopicViewSerializer do
   it 'shows valid reactions' do
     SiteSetting.discourse_reactions_enabled_reactions = "laughing|heart|-open_mouth|-cry|-angry|thumbsup|-thumbsdown"
     json = TopicViewSerializer.new(topic_view, scope: Guardian.new, root: false).as_json
-    expect(json[:valid_reactions]).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown))
+    expect(json[:valid_reactions]).to eq(%w(laughing heart open_mouth cry angry thumbsup thumbsdown).to_set)
   end
 end


### PR DESCRIPTION
We have SiteSetting called `post_undo_action_window_mins` and it should be respected by reactions

In addition, I fixed specs