### PR TITLE
Small refactoring

### DIFF
--- a/app/controllers/discourse_reactions/custom_reactions_controller.rb
+++ b/app/controllers/discourse_reactions/custom_reactions_controller.rb
@@ -7,7 +7,7 @@ module DiscourseReactions
     def toggle
       return render_json_error(@post) unless DiscourseReactions::Reaction.valid_reactions.include?(params[:reaction])
 
-      DiscourseReactions::ReactionManager.toggle!(params[:reaction], current_user, guardian, @post)
+      DiscourseReactions::ReactionManager.new(reaction_value: params[:reaction], user: current_user, guardian: guardian, post: @post).toggle!
 
       @post.publish_change_to_clients! :acted
 

--- a/app/models/discourse_reactions/reaction.rb
+++ b/app/models/discourse_reactions/reaction.rb
@@ -16,9 +16,13 @@ module DiscourseReactions
 
     def self.valid_reactions
       Set[
-        DiscourseReactions::ReactionManager.main_reaction_id,
+        DiscourseReactions::Reaction.main_reaction_id,
         *SiteSetting.discourse_reactions_enabled_reactions.split(/\|-?/)
       ]
+    end
+
+    def self.main_reaction_id
+      SiteSetting.discourse_reactions_like_icon.gsub('-', '')
     end
   end
 end

--- a/app/services/discourse_reactions/reaction_manager.rb
+++ b/app/services/discourse_reactions/reaction_manager.rb
@@ -2,75 +2,75 @@
 
 module DiscourseReactions
   class ReactionManager
-    class << self
-      def main_reaction_id
-        case SiteSetting.discourse_reactions_like_icon
-        when 'heart'
-          'heart'
-        when 'star'
-          'star'
-        when 'thumbs-up'
-          'thumbsup'
-        else
-          'heart'
-        end
-      end
+    def initialize(reaction_value:, user:, guardian:, post:)
+      @reaction_value = reaction_value
+      @user = user
+      @guardian = guardian
+      @post = post
+    end
 
-      def toggle!(reaction, user, guardian, post)
-        ActiveRecord::Base.transaction do
-          if reaction == DiscourseReactions::ReactionManager.main_reaction_id
-            like = post.post_actions.find_by(user: user, post_action_type_id: PostActionType.types[:like])
-            if like && !guardian.can_delete_post_action?(like)
-              raise Discourse::InvalidAccess
-            end
-            like ? remove_shadow_like(user, post) : add_shadow_like(user, post)
-          else
-            PostAction.limit_action!(user, post, PostActionType.types[:like])
-            reaction = reaction_scope(post, reaction).first_or_create
-            reaction_user = reaction_user_scope(reaction, user)&.first_or_initialize
-            if reaction_user.persisted?
-              unless guardian.can_delete_reaction_user?(reaction_user)
-                raise Discourse::InvalidAccess
-              end
-              reaction_user.destroy
-              remove_reaction_notification(user, reaction)
-            else
-              reaction_user.save!
-              add_reaction_notification(user, reaction)
-            end
-            reaction.destroy if reaction.reload.reaction_users_count == 0
-          end
-        end
+    def toggle!
+      ActiveRecord::Base.transaction do
+        @reaction_value == DiscourseReactions::Reaction.main_reaction_id ? toggle_like : toggle_reaction
       end
+    end
 
-      private
+    private
 
-      def add_reaction_notification(user, reaction)
-        DiscourseReactions::ReactionNotification.new(reaction, user).create
-      end
+    def toggle_like
+      like = @post.post_actions.find_by(user: @user, post_action_type_id: post_action_like_type)
+      raise Discourse::InvalidAccess if like && !@guardian.can_delete_post_action?(like)
+      like ? remove_shadow_like : add_shadow_like
+    end
 
-      def remove_reaction_notification(user, reaction)
-        DiscourseReactions::ReactionNotification.new(reaction, user).delete
-      end
+    def toggle_reaction
+      PostAction.limit_action!(@user, @post, post_action_like_type)
+      @reaction = reaction_scope.first_or_create
+      @reaction_user = reaction_user_scope&.first_or_initialize
+      @reaction_user.persisted? ? remove_reaction : add_reaction
+    end
 
-      def reaction_scope(post, reaction)
-        DiscourseReactions::Reaction.where(post_id: post.id,
-                                           reaction_value: reaction,
-                                           reaction_type: DiscourseReactions::Reaction.reaction_types['emoji'])
-      end
+    def post_action_like_type
+      PostActionType.types[:like]
+    end
 
-      def reaction_user_scope(reaction, user)
-        return nil unless reaction
-        DiscourseReactions::ReactionUser.where(reaction_id: reaction.id, user_id: user.id)
-      end
+    def add_reaction_notification
+      DiscourseReactions::ReactionNotification.new(@reaction, @user).create
+    end
 
-      def add_shadow_like(user, post)
-        PostActionCreator.like(user, post)
-      end
+    def remove_reaction_notification
+      DiscourseReactions::ReactionNotification.new(@reaction, @user).delete
+    end
 
-      def remove_shadow_like(user, post)
-        PostActionDestroyer.new(user, post, PostActionType.types[:like]).perform
-      end
+    def reaction_scope
+      DiscourseReactions::Reaction.where(post_id: @post.id,
+                                         reaction_value: @reaction_value,
+                                         reaction_type: DiscourseReactions::Reaction.reaction_types['emoji'])
+    end
+
+    def reaction_user_scope
+      return nil unless @reaction
+      DiscourseReactions::ReactionUser.where(reaction_id: @reaction.id, user_id: @user.id)
+    end
+
+    def add_shadow_like
+      PostActionCreator.like(@user, @post)
+    end
+
+    def remove_shadow_like
+      PostActionDestroyer.new(@user, @post, post_action_like_type).perform
+    end
+
+    def add_reaction
+      @reaction_user.save!
+      add_reaction_notification
+    end
+
+    def remove_reaction
+      raise Discourse::InvalidAccess if !@guardian.can_delete_reaction_user?(@reaction_user)
+      @reaction_user.destroy
+      remove_reaction_notification
+      @reaction.destroy if @reaction.reload.reaction_users_count == 0
     end
   end
 end

--- a/plugin.rb
+++ b/plugin.rb
@@ -112,13 +112,7 @@ after_initialize do
 
   add_to_serializer(:post, :reaction_users_count) do
     return object.reaction_users_count unless object.reaction_users_count.nil?
-    (
-      object.reactions.map(&:reaction_users).flatten.map(&:user_id) |
-      object.post_actions.select do |action|
-        action.post_action_type_id == PostActionType.types[:like] &&
-        action.deleted_at.blank?
-      end.map(&:user_id)
-    ).uniq.count
+    TopicViewSerializer.posts_reaction_users_count(object.id)[object.id]
   end
 
   add_to_serializer(:post, :current_user_used_main_reaction) do

--- a/plugin.rb
+++ b/plugin.rb
@@ -72,7 +72,7 @@ after_initialize do
     end
     return reactions if likes.blank?
     like_reaction = {
-      id: DiscourseReactions::ReactionManager.main_reaction_id,
+      id: DiscourseReactions::Reaction.main_reaction_id,
       type: :emoji,
       users: likes.map { |like| { username: like.user.username, avatar_template: like.user.avatar_template, can_undo: scope.can_delete_post_action?(like) } },
       count: likes.length
@@ -103,7 +103,7 @@ after_initialize do
 
     return reactions if like.blank?
     like_reaction = {
-      id: DiscourseReactions::ReactionManager.main_reaction_id,
+      id: DiscourseReactions::Reaction.main_reaction_id,
       type: :emoji,
       can_undo: scope.can_delete_post_action?(like)
     }

--- a/spec/serializers/topic_view_serializer_spec.rb
+++ b/spec/serializers/topic_view_serializer_spec.rb
@@ -56,12 +56,12 @@ describe TopicViewSerializer do
 
       expect(json[:post_stream][:posts][1][:reaction_users_count]).to eq(0)
 
-      DiscourseReactions::ReactionManager.toggle!("heart", user_2, Guardian.new(user_2), post_2)
+      DiscourseReactions::ReactionManager.new(reaction_value: "heart", user: user_2, guardian: Guardian.new(user_2), post: post_2).toggle!
       json = TopicViewSerializer.new(TopicView.new(topic), scope: Guardian.new(user_2), root: false).as_json
 
       expect(json[:post_stream][:posts][1][:reaction_users_count]).to eq(1)
 
-      DiscourseReactions::ReactionManager.toggle!("heart", user_2, Guardian.new(user_2), post_2)
+      DiscourseReactions::ReactionManager.new(reaction_value: "heart", user: user_2, guardian: Guardian.new(user_2), post: post_2).toggle!
       json = TopicViewSerializer.new(TopicView.new(topic), scope: Guardian.new(user_2), root: false).as_json
 
       expect(json[:post_stream][:posts][1][:reaction_users_count]).to eq(0)


### PR DESCRIPTION
Share count code between TopicViewSerializer and PostSerializer

Also, create an instance of ReactionManager to not pass the same arguments over and over again to methods